### PR TITLE
RabbitMQ specific STOMP queue subscription not owned by STOMP support added

### DIFF
--- a/source/Messages/StompBinaryMessageSerializer.cs
+++ b/source/Messages/StompBinaryMessageSerializer.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Netina.Stomp.Client.Messages
+{
+    public class StompBinaryMessageSerializer
+    {
+        public byte[] Serialize(StompMessage message)
+        {
+            var resultBuffer = new List<byte>();
+            resultBuffer.AddRange(Encoding.UTF8.GetBytes($"{message.Command}\n"));
+
+            if (message.Headers?.Count > 0)
+            {
+                foreach (var messageHeader in message.Headers)
+                {
+                    resultBuffer.AddRange(Encoding.UTF8.GetBytes($"{messageHeader.Key}:{messageHeader.Value}\n"));
+                }
+            }
+            resultBuffer.Add((byte)'\n');
+            resultBuffer.AddRange(message.BinaryBody);
+            resultBuffer.Add((byte)'\0');
+
+            return resultBuffer.ToArray();
+        }
+
+        public StompMessage Deserialize(byte[] message)
+        {
+            var headerBuffer = new List<byte>();
+            var bodyBuffer = new List<byte>();
+            byte previousByte = 0;
+            var isBodyStarted = false;
+            foreach (var currentByte in message)
+            {
+                if (currentByte == previousByte && previousByte == 10)
+                {
+                    isBodyStarted = true;
+                }
+                else
+                {
+                    if (isBodyStarted)
+                    {
+                        bodyBuffer.Add(currentByte);
+                    }
+                    else
+                    {
+                        headerBuffer.Add(currentByte);
+                    }
+                }
+
+                previousByte = currentByte;
+            }
+
+            var command = string.Empty;
+            var headers = new Dictionary<string, string>();
+
+            if (headerBuffer.Count > 0)
+            {
+                var stringHeader = Encoding.UTF8.GetString(headerBuffer.ToArray());
+
+                using (var reader = new StringReader(stringHeader))
+                {
+                    command = reader.ReadLine();
+                    var header = reader.ReadLine();
+                    while (!string.IsNullOrEmpty(header))
+                    {
+                        var separatorIndex = header.IndexOf(':');
+                        if (separatorIndex != -1)
+                        {
+                            var name = header.Substring(0, separatorIndex);
+                            var value = header.Substring(separatorIndex + 1);
+                            headers[name] = value;
+                        }
+
+                        header = reader.ReadLine() ?? string.Empty;
+                    }
+                }
+            }
+
+            return new StompMessage(command, bodyBuffer.ToArray(), headers);
+        }
+    }
+}

--- a/source/Messages/StompMessage.cs
+++ b/source/Messages/StompMessage.cs
@@ -5,29 +5,47 @@ namespace Netina.Stomp.Client.Messages
     public class StompMessage
     {
         public IDictionary<string, string> Headers { get; }
-        public string Body { get; }
+        public string TextBody { get; }
+        public byte[] BinaryBody { get; }
         public string Command { get; }
+
+        public StompMessageBodyType BodyType { get; }
 
         public StompMessage(string command)
             : this(command, string.Empty)
         {
         }
 
-        public StompMessage(string command, string body)
-            : this(command, body, new Dictionary<string, string>())
+        public StompMessage(string command, string textBody)
+            : this(command, textBody, new Dictionary<string, string>())
         {
         }
 
         public StompMessage(string command, IDictionary<string, string> headers)
             : this(command, string.Empty, headers)
         {
+
         }
 
-        public StompMessage(string command, string body, IDictionary<string, string> headers)
+        public StompMessage(string command, string textBody, IDictionary<string, string> headers)
         {
             Command = command;
-            Body = body;
+            TextBody = textBody;
             Headers = headers;
+            BodyType = string.IsNullOrEmpty(textBody) ? StompMessageBodyType.Empty : StompMessageBodyType.Text;
+        }
+
+        public StompMessage(string command, byte[] binBody)
+            : this(command, binBody, new Dictionary<string, string>())
+        {
+        }
+
+        public StompMessage(string command, byte[] binBody, IDictionary<string, string> headers)
+        {
+            Command = command;
+            BinaryBody = binBody;
+            Headers = headers;
+            BodyType = binBody == null || binBody.Length == 0 ? StompMessageBodyType.Empty : StompMessageBodyType.Binary;
         }
     }
 }

--- a/source/Messages/StompMessageBodyType.cs
+++ b/source/Messages/StompMessageBodyType.cs
@@ -1,0 +1,9 @@
+﻿namespace Netina.Stomp.Client.Messages
+{
+    public enum StompMessageBodyType
+    {
+        Text,
+        Binary,
+        Empty
+    }
+}

--- a/source/Messages/StompTextMessageSerializer.cs
+++ b/source/Messages/StompTextMessageSerializer.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Netina.Stomp.Client.Messages
 {
-    public class StompMessageSerializer
+    public class StompTextMessageSerializer
     {
         public string Serialize(StompMessage message)
         {
@@ -21,7 +21,7 @@ namespace Netina.Stomp.Client.Messages
             }
 
             buffer.Append('\n');
-            buffer.Append(message.Body);
+            buffer.Append(message.TextBody);
             buffer.Append('\0');
 
             return buffer.ToString();

--- a/source/Netina.Stomp.Client.csproj
+++ b/source/Netina.Stomp.Client.csproj
@@ -22,8 +22,8 @@ Add ACK &amp; NACK Commands</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Websocket.Client" Version="4.4.43" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Websocket.Client" Version="4.6.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Problem**

- Binary message types of WebSockets are not supported
- RabbitMQ STOMP implementation requires to add "/amq" prefix in order to subscribe to a queue created not by STOMP, but the messages received via this subscription are missing this prefix. As result, it is impossible to consume existing queues in RabbitMQ with this client.


**Solution**

- Binary serializer added and StompMessage updated to support binary body payload
- A check is added to a HandleMessage method if subscribers dictionary contains destination from headers, and if not, attempt will be made to find the same named destination, but with "amq" prefix.

