### PR TITLE
Binary serialization/deserialization support; support for proxy

### DIFF
--- a/source/Messages/StompBinaryMessageSerializer.cs
+++ b/source/Messages/StompBinaryMessageSerializer.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Netina.Stomp.Client.Utils;
+using System.Linq;
+
+namespace Netina.Stomp.Client.Messages
+{
+    public class StompBinaryMessageSerializer
+    {
+        public byte[] Serialize(StompMessage message)
+        {
+            var resultBuffer = new List<byte>();
+            resultBuffer.AddRange(Encoding.UTF8.GetBytes($"{message.Command}\n"));
+
+            if (message.Headers?.Count > 0)
+            {
+                foreach (var messageHeader in message.Headers)
+                {
+                    resultBuffer.AddRange(Encoding.UTF8.GetBytes($"{messageHeader.Key}:{messageHeader.Value}\n"));
+                }
+            }
+
+            resultBuffer.Add((byte)'\n');
+            resultBuffer.AddRange(message.BinaryBody);
+            resultBuffer.Add((byte)'\0');
+
+            return resultBuffer.ToArray();
+        }
+
+        public StompMessage Deserialize(byte[] message)
+        {
+            var headerBuffer = new List<byte>();
+            var bodyBuffer = new List<byte>();
+            byte previousByte = 0;
+            var isBodyStarted = false;
+
+            // Building header and body buffers
+            foreach (var currentByte in message)
+            {
+                if (!isBodyStarted && currentByte == previousByte && previousByte == (byte)'\n')
+                {
+                    isBodyStarted = true;
+                }
+                else
+                {
+                    if (isBodyStarted)
+                    {
+                        bodyBuffer.Add(currentByte);
+                    }
+                    else
+                    {
+                        headerBuffer.Add(currentByte);
+                    }
+                }
+
+                previousByte = currentByte;
+            }
+
+            // Doing a cleanup of a body buffer according to a frame description:
+            // "The body is then followed by the NULL octet. The NULL octet can be optionally followed by multiple EOLs"
+            var ignoredChars = new byte[] { (byte)'\n', (byte)'\r' };
+            var messageEnd = (byte)'\0';
+            for (var index = bodyBuffer.Count - 1; index >= 0; index--)
+            {
+                var currentByte = bodyBuffer[index];
+                if (ignoredChars.Contains(currentByte))
+                {
+                    bodyBuffer.RemoveAt(index);
+                    continue;
+                }
+
+                if (currentByte == messageEnd)
+                {
+                    bodyBuffer.RemoveAt(index);
+                }
+
+                break;
+            }
+
+            var command = string.Empty;
+            var headers = new Dictionary<string, string>();
+
+            // Parse headers
+            if (headerBuffer.Count > 0)
+            {
+                var stringHeader = Encoding.UTF8.GetString(headerBuffer.ToArray());
+
+                using (var reader = new StringReader(stringHeader))
+                {
+                    command = reader.ReadLine();
+                    var header = reader.ReadLine();
+                    while (!string.IsNullOrEmpty(header))
+                    {
+                        var separatorIndex = header.IndexOf(':');
+                        if (separatorIndex != -1)
+                        {
+                            var name = header.Substring(0, separatorIndex);
+                            var value = header.Substring(separatorIndex + 1);
+                            headers[name] = value;
+                        }
+
+                        header = reader.ReadLine() ?? string.Empty;
+                    }
+                }
+            }
+
+            // Check body content length is present
+            if (headers.TryGetValue(StompHeader.ContentLength, out var contentLength))
+            {
+                if (long.TryParse(contentLength, out var length))
+                {
+                    if (length != bodyBuffer.Count)
+                    {
+                        throw new ApplicationException(
+                            "STOMP: Content length header value is different then actual length of bytes received.");
+                    }
+                }
+            }
+
+
+            return new StompMessage(command, bodyBuffer.ToArray(), headers);
+        }
+    }
+}

--- a/source/Messages/StompMessage.cs
+++ b/source/Messages/StompMessage.cs
@@ -5,29 +5,47 @@ namespace Netina.Stomp.Client.Messages
     public class StompMessage
     {
         public IDictionary<string, string> Headers { get; }
-        public string Body { get; }
+        public string TextBody { get; }
+        public byte[] BinaryBody { get; }
         public string Command { get; }
+
+        public StompMessageBodyType BodyType { get; }
 
         public StompMessage(string command)
             : this(command, string.Empty)
         {
         }
 
-        public StompMessage(string command, string body)
-            : this(command, body, new Dictionary<string, string>())
+        public StompMessage(string command, string textBody)
+            : this(command, textBody, new Dictionary<string, string>())
         {
         }
 
         public StompMessage(string command, IDictionary<string, string> headers)
             : this(command, string.Empty, headers)
         {
+
         }
 
-        public StompMessage(string command, string body, IDictionary<string, string> headers)
+        public StompMessage(string command, string textBody, IDictionary<string, string> headers)
         {
             Command = command;
-            Body = body;
+            TextBody = textBody;
             Headers = headers;
+            BodyType = string.IsNullOrEmpty(textBody) ? StompMessageBodyType.Empty : StompMessageBodyType.Text;
+        }
+
+        public StompMessage(string command, byte[] binBody)
+            : this(command, binBody, new Dictionary<string, string>())
+        {
+        }
+
+        public StompMessage(string command, byte[] binBody, IDictionary<string, string> headers)
+        {
+            Command = command;
+            BinaryBody = binBody;
+            Headers = headers;
+            BodyType = binBody == null || binBody.Length == 0 ? StompMessageBodyType.Empty : StompMessageBodyType.Binary;
         }
     }
 }

--- a/source/Messages/StompMessageBodyType.cs
+++ b/source/Messages/StompMessageBodyType.cs
@@ -1,0 +1,9 @@
+﻿namespace Netina.Stomp.Client.Messages
+{
+    public enum StompMessageBodyType
+    {
+        Text,
+        Binary,
+        Empty
+    }
+}

--- a/source/Messages/StompTextMessageSerializer.cs
+++ b/source/Messages/StompTextMessageSerializer.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Netina.Stomp.Client.Messages
 {
-    public class StompMessageSerializer
+    public class StompTextMessageSerializer
     {
         public string Serialize(StompMessage message)
         {
@@ -21,7 +21,7 @@ namespace Netina.Stomp.Client.Messages
             }
 
             buffer.Append('\n');
-            buffer.Append(message.Body);
+            buffer.Append(message.TextBody);
             buffer.Append('\0');
 
             return buffer.ToString();

--- a/source/Netina.Stomp.Client.csproj
+++ b/source/Netina.Stomp.Client.csproj
@@ -22,8 +22,8 @@ Add ACK &amp; NACK Commands</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Websocket.Client" Version="4.4.43" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Websocket.Client" Version="4.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Utils/StompCommand.cs
+++ b/source/Utils/StompCommand.cs
@@ -15,5 +15,8 @@
         public const string Connected = "CONNECTED";
         public const string Message = "MESSAGE";
         public const string Error = "ERROR";
+
+        //Fictional
+        public const string HeartBeat = "HEARTBEAT";
     }
 }

--- a/source/Utils/StompHeader.cs
+++ b/source/Utils/StompHeader.cs
@@ -1,0 +1,23 @@
+﻿namespace Netina.Stomp.Client.Utils
+{
+    public static class StompHeader
+    {
+        public const string ContentLength = "content-length";
+        public const string ContentType = "content-type";
+        public const string AcceptVersion = "accept-version";
+        public const string Version = "version";
+        public const string Host = "host";
+        public const string Login = "login";
+        public const string Passcode = "passcode";
+        public const string Heartbeat = "heart-beat";
+        public const string Id = "id";
+        public const string Acknowledge = "ack";
+        public const string Transaction = "transaction";
+        public const string MessageId = "message-id";
+        public const string ReceiptId = "receipt-id";
+        public const string Receipt = "receipt";
+
+        public const string Destination = "destination";
+        public const string Subscription = "subscription";
+    }
+}


### PR DESCRIPTION
As we're working with RabbitMQ by both AMQP and STOMP, it was required to add binary serialization support. 
Also, we're mostly consuming existing queues, and current implementation would throw an exception in this case. It is still problematic to subscribe to existing queue - as RabbitMQ may use different paths, but it's not throwing an exception now :)


Here is the list of implemented improvements :
- binary serialization/deserialization
- existing queue subscription
- web proxy support
- hearbeat message type added
- nugets updated